### PR TITLE
CakePHP 2.9.0 deprecated the Object class in favour of CakeObject

### DIFF
--- a/Lib/Queue.php
+++ b/Lib/Queue.php
@@ -9,7 +9,7 @@
 * @license MIT
 */
 App::uses('QueueUtil','Queue.Lib');
-class Queue extends Object {
+class Queue extends CakeObject {
 	/**
 	* Placeholder for Task
 	*/


### PR DESCRIPTION
http://bakery.cakephp.org/2016/09/18/cakephp_290_289_released.html
